### PR TITLE
Remove print statement from image list

### DIFF
--- a/fandogh_cli/fandogh_client/__init__.py
+++ b/fandogh_cli/fandogh_client/__init__.py
@@ -99,7 +99,6 @@ def get_images():
     else:
         result = response.json()
         for item in result:
-            print(item)
             item['last_version_version'] = (item.get('last_version', {}) or {}).get('version', '--')
             item['last_version_date'] = (item.get('last_version', {}) or {}).get('date', '--')
         return result


### PR DESCRIPTION
@psycho-ir Please release this change ASAP, because `fandogh image list` outputs a lot of JSON stuff.