### PR TITLE
Fix click problem in service dump and some dependencies.

### DIFF
--- a/fandogh_cli/service_commands.py
+++ b/fandogh_cli/service_commands.py
@@ -269,7 +269,7 @@ def service_apply(file, parameters, detach, hide_manifest):
 
 
 @click.command('dump', cls=FandoghCommand)
-@click.option('-s', '--service', '--name', prompt='Service name')
+@click.option('-s', '--service', '--name', 'name', prompt='Service name')
 def service_dump(name):
     click.echo(yaml.safe_dump(dump_manifest(name), default_flow_style=False))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests-toolbelt
 pytz
 tzlocal
 websocket-client
+cryptography>=2.3

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
                       "pytz",
                       "tzlocal",
                       "pyyaml",
+                      "cryptography>=2.3",
                       "websocket-client==0.54.0"],
     author_email='soroosh.sarabadani@gmail.com',
     url='https://github.com/fandoghpaas/fandogh-cli',


### PR DESCRIPTION
1. The first commit is to sync forked repo with the original repo.
2. The second one is to fix click problem in the new version of click. You can see what happened with running `fandogh service dump --name ...` if your `click` is upgraded to the newest version.
3. The pyOpenSSL depends on `cryptography>=2.3`.
4. Add -h and --hide same as `service apply` for `service dump`.